### PR TITLE
Fix 'Get Bookmarks' Method

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -65,7 +65,7 @@ Reader.prototype.user = function (cb) {
  */
 Reader.prototype.bookmarks = function (options, cb) {
   this.request('GET', '/bookmarks', {qs: options}, function (err, res, body) {
-    delete body.conditions;
+    if (body) delete body.conditions;
     cb(err, body);
   });
 };


### PR DESCRIPTION
Readability's been down recently :'(

Noticed that get bookmarks method doesn't account for an error from Readability. It tries to delete a property from `body` without checking if it exists. 

Really small fix ... checks if `body` exists before trying to delete `conditions` property.
